### PR TITLE
Adding namePrefix feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Supported render engines and materials:
 
 Here the text version for copy+paste :  
 
+```
 from SubstancePainterToMaya import main  
 reload(main)  
 main.SPtoM()
+```
 
 ## New
 

--- a/SubstancePainterToMaya/UI.py
+++ b/SubstancePainterToMaya/UI.py
@@ -107,6 +107,16 @@ class PainterToMayaUI:
         )
         self.namingConventionSubLayoutValue.addWidget(self.textureSet)
 
+        # new feature: choose the prefix to ignore
+        self.namePrefixLabel = QtWidgets.QLabel('namePrefix')
+        self.namingConventionSubLayoutLabel.addWidget(self.namePrefixLabel)
+
+        self.namePrefix = QtWidgets.QLineEdit('Type your namePrefix')
+        self.namePrefix.setToolTip(
+            'The namePrefix you want to ignore in the naming convention'
+        )
+        self.namingConventionSubLayoutValue.addWidget(self.namePrefix)
+
         self.mapLabel = QtWidgets.QLabel('map')
         self.namingConventionSubLayoutLabel.addWidget(self.mapLabel)
         self.mapLabel.resize(200,200)

--- a/SubstancePainterToMaya/helper.py
+++ b/SubstancePainterToMaya/helper.py
@@ -23,22 +23,26 @@ def before(value, a):
     if pos_a == -1: return ""
     return value[0:pos_a]
 
+def withoutPrefix(ui):
+    # removing prefix from textureSet
+    textureSet = ui.textureSet.text().encode("ascii")
+    if ui.namePrefix.text().encode("ascii") is None:
+        return ''
+    else:
+        namePrefix = ui.namePrefix.text().encode("ascii")
+        if textureSet.startswith(namePrefix):
+            return textureSet[(len(namePrefix)):]
+
+def appendPrefix(ui, input_str):
+    namePrefix = ui.namePrefix.text().encode("ascii")
+    return ''.join([namePrefix, input_str])
+
 def splitNamingConvention(ui, textures):
 
     construction = []
     textureSetSeparator = '_'
     mapSeparator = '_'
-    textureSet = ui.textureSet.text().encode("ascii")
-
-    # removing prefix from textureSet
-    if ui.namePrefix.text().encode("ascii") is None:
-        namePrefix = ''
-    else:
-        namePrefix = ui.namePrefix.text().encode("ascii")
-        if textureSet.startswith(namePrefix):
-            textureSet = textureSet[(len(namePrefix)):]
-
-
+    textureSet = withoutPrefix(ui)
     map = ui.map.text().encode("ascii")
 
     for texture in textures:
@@ -103,7 +107,7 @@ def listTextures(ui, renderer, foundFiles, allTextureSets):
     for texture in foundFiles:
 
         if not allTextureSets:
-            if not ui.textureSet.text().encode("ascii") in texture:
+            if not withoutPrefix(ui) in texture:
                 continue
 
         # Create the texture path
@@ -142,7 +146,7 @@ def listTextures(ui, renderer, foundFiles, allTextureSets):
                             nameStart += 1
 
                 mapName = name
-                textureSetName = textureSet
+                textureSetName = appendPrefix(ui, textureSet)
 
                 if mapName and textureSetName:
 

--- a/SubstancePainterToMaya/helper.py
+++ b/SubstancePainterToMaya/helper.py
@@ -29,6 +29,16 @@ def splitNamingConvention(ui, textures):
     textureSetSeparator = '_'
     mapSeparator = '_'
     textureSet = ui.textureSet.text().encode("ascii")
+
+    # removing prefix from textureSet
+    if ui.namePrefix.text().encode("ascii") is None:
+        namePrefix = ''
+    else:
+        namePrefix = ui.namePrefix.text().encode("ascii")
+        if textureSet.startswith(namePrefix):
+            textureSet = textureSet[(len(namePrefix)):]
+
+
     map = ui.map.text().encode("ascii")
 
     for texture in textures:


### PR DESCRIPTION
Our workflow uses slightly different naming conventions that put different prefixes in front of the material/texture, for example:
M_<object> = Materials
T_<object> = Textures

Putting the namePrefix option helps users to put their designated prefixes for more descriptive uses or different standards. I wrote this for my team's needs, probably it's also useful for the community.